### PR TITLE
refactor: Add proper TypeScript types for i18n

### DIFF
--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "../globals.css";
 import { i18n } from "@/i18n/config";
 import { iranSans, sfPro } from "@/config/fonts";
+import type { Locale } from "@/types/i18n";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -17,7 +18,7 @@ export default function RootLayout({
   params: { lang },
 }: Readonly<{
   children: React.ReactNode;
-  params: { lang: string };
+  params: { lang: Locale };
 }>) {
   return (
     <html lang={lang}>

--- a/src/app/[lang]/page.tsx
+++ b/src/app/[lang]/page.tsx
@@ -1,6 +1,7 @@
 import { i18n } from "@/i18n/config";
 import { getDictionary } from "@/i18n/get-dictionary";
 import Link from "next/link";
+import type { Locale } from "@/types/i18n";
 
 export async function generateStaticParams() {
   return i18n.locales.map((lang) => ({ lang }));
@@ -9,9 +10,9 @@ export async function generateStaticParams() {
 export default async function Home({
   params: { lang },
 }: {
-  params: { lang: string };
+  params: { lang: Locale };
 }) {
-  const dict = await getDictionary(lang as any);
+  const dict = await getDictionary(lang);
 
   return (
     <div className="flex flex-col items-center justify-center h-screen">

--- a/src/i18n/get-dictionary.ts
+++ b/src/i18n/get-dictionary.ts
@@ -1,8 +1,9 @@
-import type { Locale } from "./config";
+import type { Locale, Dictionary } from "@/types/i18n";
 
 const dictionaries = {
   fa: () => import("./dictionaries/fa.json").then((module) => module.default),
   en: () => import("./dictionaries/en.json").then((module) => module.default),
 };
 
-export const getDictionary = async (locale: Locale) => dictionaries[locale]();
+export const getDictionary = async (locale: Locale): Promise<Dictionary> =>
+  dictionaries[locale]();

--- a/src/types/i18n.ts
+++ b/src/types/i18n.ts
@@ -1,0 +1,8 @@
+import { i18n } from "@/i18n/config";
+
+export type Locale = (typeof i18n)["locales"][number];
+
+export interface Dictionary {
+  welcome: string;
+  name: string;
+}


### PR DESCRIPTION
Changes: - src/types/i18n.ts: Add new types for i18n - src/i18n/get-dictionary.ts: Use proper types - src/app/[lang]/page.tsx: Use proper types - src/app/[lang]/layout.tsx: Use proper types